### PR TITLE
replace mimemagic with marcel

### DIFF
--- a/carrierwave-base64.gemspec
+++ b/carrierwave-base64.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'carrierwave', '>= 0.8.0'
   spec.add_dependency 'mime-types', '~> 3.0'
-  spec.add_dependency 'mimemagic', '~> 0.3.2'
+  spec.add_dependency 'marcel', '~> 1.0.0'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'carrierwave-mongoid'

--- a/lib/carrierwave/base64/base64_string_io.rb
+++ b/lib/carrierwave/base64/base64_string_io.rb
@@ -1,5 +1,4 @@
-require 'mimemagic'
-require 'mimemagic/overlay'
+require 'marcel'
 
 module Carrierwave
   module Base64
@@ -48,7 +47,7 @@ module Carrierwave
 
       # Determine content type from input, with provided type as fallback
       def get_file_extension(description, bytes)
-        detected_type = MimeMagic.by_magic(bytes)
+        detected_type = Marcel::Magic.by_magic(bytes)
         content_type = (detected_type && detected_type.type) ||
                        description.split(';base64').first
         mime_type = MIME::Types[content_type].last


### PR DESCRIPTION
to be free from mimemagic, use updated marcel like CarrierWave https://github.com/carrierwaveuploader/carrierwave/pull/2551

to remove mimemagic dependency, Rails(marcel) have been updated in this Pull Request https://github.com/rails/marcel/pull/30
with this change, we are able to use marcel to know content types and mime types from uploaded file as same as mimemagic.

last week we have a big problem with mimemagic lisencing.
most of it have been resolved but it is better to use rails gem marcel to be static.
https://github.com/y9v/carrierwave-base64/issues/84
 